### PR TITLE
Adicionando volta para o menu principal após operação

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -128,7 +128,7 @@ void desviopadrao()
 
         status=0;
         cout << endl
-             << "Insira 0 para sair ou 1 para reiniciar: ";
+             << "Insira 0 para voltar para o menu ou 1 para reiniciar: ";
 
         cin >> status;
     }
@@ -229,7 +229,7 @@ void mmq()
 
         status=0;
         cout << endl
-             << "Insira 0 para sair ou 1 para reiniciar: ";
+             << "Insira 0 para voltar para o menu ou 1 para reiniciar: ";
 
         cin >> status;
     }
@@ -241,23 +241,25 @@ int main()
 {
     int choice = 0;
 
-    cout << setprecision(12) << "\t\t\tMenu \n";
-    cout << "1 - Desvio padrao da media ou desvio padrao amostral\n";
-    cout << "2 - Regressao Linear (MMQ)\n";
-    cout << "3 - Sair\n";
-
-    cin >> choice;
-
-    switch (choice)
+    while (true)
     {
-    case 1:
-        desviopadrao();
-        break;
-    case 2:
-        mmq();
-        break;
-    default:
-        break;
+        cout << setprecision(12) << "\t\t\tMenu \n";
+        cout << "1 - Desvio padrao da media ou desvio padrao amostral\n";
+        cout << "2 - Regressao Linear (MMQ)\n";
+        cout << "3 - Sair\n";
+
+        cin >> choice;
+
+        if (choice == 1)
+        {
+            desviopadrao();
+        }
+        else if (choice == 2)
+        {
+            mmq();
+        } else {
+            break;
+        }
     }
 
     return 0;


### PR DESCRIPTION
Achei que seria legal voltar para o menu principal para trocar de operações sem ter que fechar e abrir o programa novamente.
Por exemplo: preciso de cacular o desvio padrão amostral e logo após isso preciso de calcular a regressão linear, então saio da primeira operação e vou para a segunda, sem ter que reabrir o programa.

Só fiz alteração no código fonte, então o build vai ter que ser executado para adicionar a funcionalidade no executável.